### PR TITLE
Add AssignmentExpressionSyntax to exception list

### DIFF
--- a/Quoter/Quoter.cs
+++ b/Quoter/Quoter.cs
@@ -180,6 +180,7 @@ public class Quoter
         // that we filter out above. Add an artificial "property value" that can be later used to
         // satisfy the first parameter of type SyntaxKind.
         if (node is AccessorDeclarationSyntax ||
+            node is AssignmentExpressionSyntax ||
             node is BinaryExpressionSyntax ||
             node is ClassOrStructConstraintSyntax ||
             node is CheckedExpressionSyntax ||

--- a/Quoter/Tests.cs
+++ b/Quoter/Tests.cs
@@ -412,6 +412,12 @@ namespace @N
     }
 
     [TestMethod]
+    public void Roundtrip27()
+    {
+        Test("class C { void M() { int x; x = 42; } }");
+    }
+
+    [TestMethod]
     public void RoundtripMissingToken()
     {
         Test("class");


### PR DESCRIPTION
Quoter throws an exception when input contains assignments. This commit
fixes the problem by adding assignment expression node to exception
list.