### PR TITLE
Add support for generating a LINQPad file

### DIFF
--- a/src/Quoter.Web/Controllers/QuoterController.cs
+++ b/src/Quoter.Web/Controllers/QuoterController.cs
@@ -11,14 +11,15 @@ namespace QuoterService.Controllers
     public class QuoterController : Controller
     {
         [HttpGet]
-        public string Get(
+        public IActionResult Get(
             string sourceText,
             NodeKind nodeKind = NodeKind.CompilationUnit,
             bool openCurlyOnNewLine = false,
             bool closeCurlyOnNewLine = false,
             bool preserveOriginalWhitespace = false,
             bool keepRedundantApiCalls = false,
-            bool avoidUsingStatic = false)
+            bool avoidUsingStatic = false,
+            bool generateLINQPad = false)
         {
             string prefix = null;
 
@@ -54,6 +55,25 @@ namespace QuoterService.Controllers
                 }
             }
 
+            if (generateLINQPad)
+            {
+                var linqpadFile = $@"<Query Kind=""Expression"">
+  <NuGetReference>Microsoft.CodeAnalysis.Compilers</NuGetReference>
+  <NuGetReference>Microsoft.CodeAnalysis.CSharp</NuGetReference>
+  <Namespace>static Microsoft.CodeAnalysis.CSharp.SyntaxFactory</Namespace>
+  <Namespace>Microsoft.CodeAnalysis.CSharp.Syntax</Namespace>
+  <Namespace>Microsoft.CodeAnalysis.CSharp</Namespace>
+  <Namespace>Microsoft.CodeAnalysis</Namespace>
+</Query>
+
+{responseText}
+";
+
+                var responseBytes = Encoding.UTF8.GetBytes(linqpadFile);
+
+                return File(responseBytes, "application/octet-stream", "Quoter.linq");
+            }
+
             responseText = HttpUtility.HtmlEncode(responseText);
 
             if (prefix != null)
@@ -61,7 +81,7 @@ namespace QuoterService.Controllers
                 responseText = "<div class=\"error\"><p>" + prefix + "</p><p>" + responseText + "</p><p><br/>P.S. Sorry!</p></div>";
             }
 
-            return responseText;
+            return Ok(responseText);
         }
     }
 }

--- a/src/Quoter.Web/wwwroot/index.html
+++ b/src/Quoter.Web/wwwroot/index.html
@@ -58,6 +58,9 @@
         <div>
             <button id="submitButton" type="button" onclick="onSubmitClick();">Get Roslyn API calls to generate this code!</button> &nbsp;<span id="working" style="display: none">Working...</span>
         </div>
+        <div>
+            <button id="LINQPadButton" type="button" onclick="onSubmitLINQPad();">Get Roslyn API calls to generate this code as LINQPad file!</button>
+        </div>
     </div>
     <div id="outputDiv" xml:space="preserve">
 CompilationUnit()

--- a/src/Quoter.Web/wwwroot/scripts.js
+++ b/src/Quoter.Web/wwwroot/scripts.js
@@ -1,7 +1,7 @@
 ﻿function onPageLoad() {
 }
 
-function onSubmitClick() {
+function generateQuery() {
     var nodeKind = document.getElementById("nodeKind").value;
     var openCurlyOnNewLine = getCheckboxValue("openCurlyOnNewLine");
     var closeCurlyOnNewLine = getCheckboxValue("closeCurlyOnNewLine");
@@ -32,7 +32,21 @@ function onSubmitClick() {
         query = query + "&avoidUsingStatic=true";
     }
 
+    return query;
+}
+
+function onSubmitClick() {
+    var query = generateQuery();
+
     getUrl(query, loadResults);
+}
+
+function onSubmitLINQPad() {
+    var query = generateQuery();
+
+    query = query + "&generateLINQPad=true";
+
+    window.location = query;
 }
 
 function getCheckboxValue(id) {


### PR DESCRIPTION
LINQPad is a great resource for giving a script a test locally. This adds the minimal header to the file required to use LINQPad meaning you can start to experiment with the code easily and see the output.