### PR TITLE
Added support for parsing member declarations

### DIFF
--- a/src/Quoter.Tests/Quoter.Tests.csproj
+++ b/src/Quoter.Tests/Quoter.Tests.csproj
@@ -6,10 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Quoter.Web/wwwroot/index.html
+++ b/src/Quoter.Web/wwwroot/index.html
@@ -25,6 +25,7 @@
                 Parse as:
                 <select id="nodeKind">
                     <option value="CompilationUnit">File</option>
+                    <option value="MemberDeclaration">Member</option>
                     <option value="Statement">Statement</option>
                     <option value="Expression">Expression</option>
                 </select>

--- a/src/Quoter/Quoter.cs
+++ b/src/Quoter/Quoter.cs
@@ -102,6 +102,8 @@ public class Quoter
         {
             case NodeKind.CompilationUnit:
                 return SyntaxFactory.ParseCompilationUnit(sourceText);
+            case NodeKind.MemberDeclaration:
+                return SyntaxFactory.ParseMemberDeclaration(sourceText);
             case NodeKind.Statement:
                 return SyntaxFactory.ParseStatement(sourceText);
             case NodeKind.Expression:
@@ -1891,6 +1893,7 @@ public class Quoter
 public enum NodeKind
 {
     CompilationUnit,
+    MemberDeclaration,
     Statement,
     Expression
 }

--- a/src/Quoter/Quoter.csproj
+++ b/src/Quoter/Quoter.csproj
@@ -7,10 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Roslyn 3.0 adds `SyntaxFactory.ParseMemberDeclaration` (see https://github.com/dotnet/roslyn/issues/367), so this PR updates to that version and adds support for using that method here.

(I have also simplified package references to take advantage of transitive nature of `<PackageReference>`.)