### PR TITLE
Bugfix for verbatim-identifiers and contextual keywords, always-false case "value.IsMissing" removed

### DIFF
--- a/src/Quoter.Tests/Tests.cs
+++ b/src/Quoter.Tests/Tests.cs
@@ -580,6 +580,14 @@ class C { }");
         Test(@"void M() { var a = M() is char and > 'H' }");
     }
 
+    [Fact]
+    public void TestIdentifiers()
+    {
+        Test(@"using System;
+var @class = 12;
+Console.WriteLine(nameof(@class));");
+    }
+
     private void Test(
         string sourceText,
         string expected,

--- a/src/Quoter/Quoter.cs
+++ b/src/Quoter/Quoter.cs
@@ -395,7 +395,7 @@ namespace RoslynQuoter
             var arguments = new List<object>();
             string methodName = SyntaxFactoryMethod("Token");
             var tokenText = value.Text;
-            bool verbatim = 
+            bool verbatim =
                 tokenText.StartsWith("@") ||
                 tokenText.Contains("\r") ||
                 tokenText.Contains("\n");
@@ -414,7 +414,7 @@ namespace RoslynQuoter
                 methodName = SyntaxFactoryMethod("Identifier");
 
                 var kind = value.Kind();
-                
+
                 if (verbatim)
                 {
                     leading = leading ?? GetEmptyTrivia("LeadingTrivia");
@@ -425,7 +425,8 @@ namespace RoslynQuoter
                     arguments.Add(escapedTokenText);
                     arguments.Add(EscapeAndQuote(value.ValueText));
                     arguments.Add(trailing);
-                } else
+                }
+                else
                 if (SyntaxFacts.GetContextualKeywordKind(value.ValueText) is var contextualKeyWord
                     && contextualKeyWord != SyntaxKind.None)
                 {


### PR DESCRIPTION
Fixes handling for identifiers like "_", "@class" and "nameof"