### PR TITLE
"ReadyToRun"- template added (similar to LinqPad-extension)

### DIFF
--- a/src/Quoter.Web/Controllers/QuoterController.cs
+++ b/src/Quoter.Web/Controllers/QuoterController.cs
@@ -42,6 +42,11 @@ namespace QuoterService.Controllers
                     };
 
                     responseText = quoter.QuoteText(arguments.SourceText, arguments.NodeKind);
+
+                    if (arguments.ReadyToRun)
+                    {
+                        responseText = ReadyToRunHelper.CreateReadyToRunCode(arguments, responseText);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -50,7 +55,7 @@ namespace QuoterService.Controllers
                     prefix = "Congratulations! You've found a bug in Quoter! Please open an issue at <a href=\"https://github.com/KirillOsenkov/RoslynQuoter/issues/new\" target=\"_blank\">https://github.com/KirillOsenkov/RoslynQuoter/issues/new</a> and paste the code you've typed above and this stack:";
                 }
             }
-
+            
             responseText = HttpUtility.HtmlEncode(responseText);
 
             if (prefix != null)

--- a/src/Quoter.Web/Dtos/QuoterRequestArgument.cs
+++ b/src/Quoter.Web/Dtos/QuoterRequestArgument.cs
@@ -12,5 +12,6 @@ namespace QuoterWeb
         public bool KeepRedundantApiCalls { get; set; }
         public bool AvoidUsingStatic { get; set; }
         public bool GenerateLinqPad { get; set; }
+        public bool ReadyToRun { get; set; }
     }
 }

--- a/src/Quoter.Web/ReadyToRunHelper.cs
+++ b/src/Quoter.Web/ReadyToRunHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace QuoterWeb
+{
+    public static class ReadyToRunHelper
+    {
+        public static string CreateReadyToRunCode(QuoterRequestArgument arguments, string roslynCode)
+        {
+            return @$"using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;{(arguments.AvoidUsingStatic ? string.Empty : @"
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;")}
+
+/*
+{arguments.SourceText}
+*/
+
+var tree = SyntaxTree(
+//CODE FROM ROSLYN QUOTER:
+{roslynCode}
+//END
+);
+
+var refApis = AppDomain.CurrentDomain.GetAssemblies()
+    .Where(a => !a.IsDynamic)
+    .Select(a => MetadataReference.CreateFromFile(a.Location));
+
+var compilation = CSharpCompilation.Create(""something"", new[] {{ tree }}, refApis);
+var diag = compilation.GetDiagnostics().Where(e => e.Severity == DiagnosticSeverity.Error).ToList();
+
+foreach(var d in diag)
+{{
+  Console.WriteLine(d);	
+}}";
+        }
+    }
+}

--- a/src/Quoter.Web/wwwroot/index.html
+++ b/src/Quoter.Web/wwwroot/index.html
@@ -56,6 +56,11 @@
             </label>
         </div>
         <div>
+            <label>
+                <input id="readyToRun" type="checkbox" />&nbsp;Ready-To-Run (with compilation and diagnostics)
+            </label>
+        </div>
+        <div>
             <button id="submitButton" type="button" onclick="onSubmitClick();">Get Roslyn API calls to generate this code!</button> &nbsp;<span id="working" style="display: none">Working...</span>
         </div>
         <div>

--- a/src/Quoter.Web/wwwroot/scripts.js
+++ b/src/Quoter.Web/wwwroot/scripts.js
@@ -27,6 +27,7 @@ function generateArguments() {
     var preserveOriginalWhitespace = getCheckboxValue("preserveOriginalWhitespace");
     var keepRedundantApiCalls = getCheckboxValue("keepRedundantApiCalls");
     var avoidUsingStatic = getCheckboxValue("avoidUsingStatic");
+    var readyToRun = getCheckboxValue("readyToRun");
     var arguments = new Object();
     arguments.sourceText = editor.getValue();
     arguments.nodeKind = nodeKind;
@@ -49,6 +50,10 @@ function generateArguments() {
 
     if (avoidUsingStatic) {
         arguments.avoidUsingStatic = true;
+    }
+
+    if (readyToRun) {
+        arguments.readyToRun = true;
     }
 
     return arguments;


### PR DESCRIPTION
Simple template to show diagnostics or to access semantic model quickly from roslyn-quoter code