### PR TITLE
Bugfix: Invalid code generation for literals with encoded entities like line breaks or unicode code points

### DIFF
--- a/src/Quoter.Tests/Tests.cs
+++ b/src/Quoter.Tests/Tests.cs
@@ -9,6 +9,26 @@ using Xunit;
 public class Tests
 {
     [Fact]
+    public void TestInterpolatedStringWithNewLine()
+    {
+        var expected = $@"InterpolatedStringExpression(
+    Token(SyntaxKind.InterpolatedStringStartToken))
+.WithContents(
+    SingletonList<InterpolatedStringContentSyntax>(
+        InterpolatedStringText()
+        .WithTextToken(
+            Token(
+                TriviaList(),
+                SyntaxKind.InterpolatedStringTextToken,
+                ""Foo \\n!"",
+                @""Foo {"\n"}!"",
+                TriviaList()))))
+.NormalizeWhitespace()";
+        
+        Test("$\"Foo \\n!\"", expected, shortenCodeWithUsingStatic: true, nodeKind: NodeKind.Expression);
+    }
+
+    [Fact]
     public void TestUsingSystemWithRedundantCalls()
     {
         Test(@"using System;

--- a/src/Quoter/Quoter.cs
+++ b/src/Quoter/Quoter.cs
@@ -436,6 +436,9 @@ namespace RoslynQuoter
                 else if (SyntaxFacts.GetContextualKeywordKind(tokenValueText) is var contextualKeyWord
                     && contextualKeyWord != SyntaxKind.None)
                 {
+                    leading = leading ?? GetEmptyTrivia("LeadingTrivia");
+                    trailing = trailing ?? GetEmptyTrivia("TrailingTrivia");
+
                     arguments.Add(leading);
                     arguments.Add(contextualKeyWord);
                     arguments.Add(escapedTokenText);

--- a/src/Quoter/Quoter.cs
+++ b/src/Quoter/Quoter.cs
@@ -408,6 +408,7 @@ namespace RoslynQuoter
                 tokenText.Contains("\r") ||
                 tokenText.Contains("\n");
             string escapedTokenText = EscapeAndQuote(tokenText, verbatim);
+            string escapedTokenValueText = EscapeAndQuote(tokenValueText);
             object leading = GetLeadingTrivia(token);
             object trailing = GetTrailingTrivia(token);
 
@@ -429,19 +430,16 @@ namespace RoslynQuoter
                     arguments.Add(leading);
                     arguments.Add(tokenKind);
                     arguments.Add(escapedTokenText);
-                    arguments.Add(EscapeAndQuote(tokenValueText));
+                    arguments.Add(escapedTokenValueText);
                     arguments.Add(trailing);
                 }
                 else if (SyntaxFacts.GetContextualKeywordKind(tokenValueText) is var contextualKeyWord
                     && contextualKeyWord != SyntaxKind.None)
                 {
-                    leading = leading ?? GetEmptyTrivia("LeadingTrivia");
-                    trailing = trailing ?? GetEmptyTrivia("TrailingTrivia");
-
                     arguments.Add(leading);
                     arguments.Add(contextualKeyWord);
                     arguments.Add(escapedTokenText);
-                    arguments.Add(escapedTokenText);
+                    arguments.Add(escapedTokenValueText);
                     arguments.Add(trailing);
                 }
                 else
@@ -458,7 +456,7 @@ namespace RoslynQuoter
                 AddIfNotNull(arguments, leading);
                 arguments.Add(tokenKind);
                 arguments.Add(escapedTokenText);
-                arguments.Add(escapedTokenText);
+                arguments.Add(escapedTokenValueText);
                 AddIfNotNull(arguments, trailing);
             }
             else if ((tokenKind == SyntaxKind.XmlTextLiteralToken ||
@@ -474,10 +472,9 @@ namespace RoslynQuoter
                 {
                     methodName = SyntaxFactoryMethod("XmlEntity");
                 }
-
                 arguments.Add(leading ?? GetEmptyTrivia("LeadingTrivia"));
                 arguments.Add(escapedTokenText);
-                arguments.Add(escapedTokenText);
+                arguments.Add(escapedTokenValueText);
                 arguments.Add(trailing ?? GetEmptyTrivia("TrailingTrivia"));
             }
             else if ((token.Parent is LiteralExpressionSyntax ||


### PR DESCRIPTION
Bugfix: Invalid code generation for literals with encoded entities like line breaks or unicode code points

Sample code:
```cs
Console.WriteLine($"Foo\n!")
```