### PR TITLE
fix: Remove unused script options

### DIFF
--- a/src/Quoter/Quoter.cs
+++ b/src/Quoter/Quoter.cs
@@ -45,18 +45,6 @@ namespace RoslynQuoter
         public bool RemoveRedundantModifyingCalls { get; set; }
         public bool ShortenCodeWithUsingStatic { get; set; }
 
-        private readonly ScriptOptions options = ScriptOptions.Default
-            .AddReferences(
-                typeof(SyntaxNode).Assembly,
-                typeof(CSharpSyntaxNode).Assembly)
-            .AddReferences("System.Runtime")
-            .AddImports(
-                "System",
-                "Microsoft.CodeAnalysis",
-                "Microsoft.CodeAnalysis.CSharp",
-                "Microsoft.CodeAnalysis.CSharp.Syntax",
-                "Microsoft.CodeAnalysis.CSharp.SyntaxFactory");
-
         public Quoter()
         {
             UseDefaultFormatting = true;


### PR DESCRIPTION
This field is not needed, and does not work on webassembly as the runtime-loaded assemblies do not have a physical location.

Latest is now running on https://roslynquoter-wasm.platform.uno