### PR TITLE
Support aliases for any type

### DIFF
--- a/.github/workflows/roslynquoter.yml
+++ b/.github/workflows/roslynquoter.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
     - name: Restore
@@ -27,7 +27,7 @@ jobs:
     - name: Publish
       run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_WEBAPP_PACKAGE_PATH }}"
     - name: Publish Artifacts
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v4
       with:
         name: webapp
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
@@ -36,7 +36,7 @@ jobs:
     needs: build
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: webapp
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ bld/
 # Roslyn cache directories
 *.vs/
 
+# Rider
+.idea/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/src/Quoter.Tests/Quoter.Tests.csproj
+++ b/src/Quoter.Tests/Quoter.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime;build;native;contentFiles;analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Quoter.Tests/Tests.cs
+++ b/src/Quoter.Tests/Tests.cs
@@ -867,6 +867,13 @@ Console.WriteLine(nameof(@class));");
             nodeKind: NodeKind.MemberDeclaration);
     }
 
+    [Fact]
+    public void TestIssue85()
+    {
+        Test("using Foo = object;");
+        Test("using Foo = (int foo, int bar);");
+    }
+
     private void Test(
         string sourceText,
         string expected,

--- a/src/Quoter/Quoter.cs
+++ b/src/Quoter/Quoter.cs
@@ -1044,12 +1044,25 @@ namespace RoslynQuoter
                 return candidates.First();
             }
 
-            var usingDirectiveSyntax = node as UsingDirectiveSyntax;
-            if (usingDirectiveSyntax != null)
+            if (node is UsingDirectiveSyntax usingDirectiveSyntax)
             {
                 if (usingDirectiveSyntax.Alias == null)
                 {
-                    candidates = candidates.Where(m => m.ToString() != "Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax UsingDirective(Microsoft.CodeAnalysis.CSharp.Syntax.NameEqualsSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.NameSyntax)");
+                    const string signatureWithNameSyntax = "Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax UsingDirective(Microsoft.CodeAnalysis.CSharp.Syntax.NameEqualsSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.NameSyntax)";
+                    const string signatureWithTypeSyntax = "Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax UsingDirective(Microsoft.CodeAnalysis.CSharp.Syntax.NameEqualsSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax)";
+
+                    candidates = candidates.Where(m => m.ToString() is not (signatureWithNameSyntax or signatureWithTypeSyntax));
+                }
+                else
+                {
+                    var preferredSignature = usingDirectiveSyntax.NamespaceOrType is NameSyntax
+                        ? "Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax UsingDirective(Microsoft.CodeAnalysis.CSharp.Syntax.NameSyntax)"
+                        : "Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax UsingDirective(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax)";
+
+                    if (candidates.FirstOrDefault(m => m.ToString() == preferredSignature) is { } preferredMethod)
+                    {
+                        return preferredMethod;
+                    }
                 }
             }
 

--- a/src/Quoter/Quoter.csproj
+++ b/src/Quoter/Quoter.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #85

I'm not 100% sure I did the right thing, as I didn't understand why you were ignoring the following method:

```csharp
Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax UsingDirective(Microsoft.CodeAnalysis.CSharp.Syntax.NameEqualsSyntax, Microsoft.CodeAnalysis.CSharp.Syntax.NameSyntax)
```

